### PR TITLE
fix -C option to check for approved strings count

### DIFF
--- a/bash/common.sh
+++ b/bash/common.sh
@@ -316,10 +316,10 @@ function check_file_status {
 
     get_file_status "$1" "$2"
     if [[ $? -eq 0 ]]; then
-        local string_count=$(get_value_using_regex "$SM_RESPONSE" "$STRING_COUNT_REGEX")
+        local approved_string_count=$(get_value_using_regex "$SM_RESPONSE" "$APPROVED_STRING_COUNT_REGEX")
         local completed_count=$(get_value_using_regex "$SM_RESPONSE" "$COMPLETED_STRING_COUNT_REGEX")
 
-        if [[ ${string_count} -gt 0 && ${string_count} -eq ${completed_count} ]]; then
+        if [[ ${approved_string_count} -gt 0 && ${approved_string_count} -eq ${completed_count} ]]; then
             SM_FILE_STATUS="completed"
         fi
 


### PR DESCRIPTION
download.sh has -C option to download files only if 100% translated.
This uses get_file_status function to check if file is “completed”; but
the logic was checking string count to completed string count and if
not all strings approved, this is not right; it should compare approved
strings to completed strings to determine 100% complete.
